### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -21,8 +21,9 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: 18
       - uses: actions/cache@v4
         with:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -36,9 +36,9 @@
 		<maven.compiler.version>3.10.1</maven.compiler.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<resilience4j.version>1.7.1</resilience4j.version>
+		<resilience4j.version>2.3.0</resilience4j.version>
 		<maven.test.skip>false</maven.test.skip>
-		<log4j.version>2.18.0</log4j.version>
+		<log4j.version>2.20.0</log4j.version>
 	</properties>
 
 	<dependencies>
@@ -71,16 +71,27 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
-			<version>2.13.3</version>
+			<version>2.18.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.3</version>
+			<version>2.18.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.18.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.18.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
-			<artifactId>ojdbc8</artifactId>
+			<artifactId>ojdbc11</artifactId>
+			<version>21.3.0.0</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -124,7 +135,7 @@
 		<dependency>
 			<groupId>org.modelmapper</groupId>
 			<artifactId>modelmapper</artifactId>
-			<version>3.1.0</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.vintage</groupId>
@@ -234,7 +245,7 @@
 					<plugin>
 						<groupId>org.hibernate.orm.tooling</groupId>
 						<artifactId>hibernate-enhance-maven-plugin</artifactId>
-						<version>6.1.1.Final</version>
+						<version>6.6.4.Final</version>
 						<executions>
 							<execution>
 								<configuration>


### PR DESCRIPTION

Change Details:

- Bump org.hibernate.orm.tooling:hibernate-enhance-maven-plugin from 6.1.1.Final to 6.6.5.Final  [Used 6.6.4.Final ]
- Bump io.github.resilience4j:resilience4j-spring-boot2 from 1.7.1 to 2.3.0 
- Bump org.modelmapper:modelmapper from 3.1.0 to 3.2.2 
- Bump com.fasterxml.jackson.core:jackson-databind from 2.13.3 to 2.13.4.2 [Used 2.18.2]
- Bump actions/setup-java from 1 to 4 
- Bump log4j.version from 2.18.0 to 2.19.0  [Used 2.20.0]
- Upgrade ojdbc8 to ojdbc11